### PR TITLE
Add Edit Student UI

### DIFF
--- a/backend/src/controllers/student.ts
+++ b/backend/src/controllers/student.ts
@@ -25,9 +25,9 @@ export type typedModel = {
   birthday: string;
   intakeDate: string;
   tourDate: string;
-  prog1: string;
-  prog2: string;
-  dietary: string;
+  prog1: string[];
+  prog2: string[];
+  dietary: string[];
   otherString: string;
 };
 

--- a/backend/src/models/student.ts
+++ b/backend/src/models/student.ts
@@ -35,10 +35,10 @@ const studentSchema = new Schema({
   intakeDate: { type: Date, required: true },
   tourDate: { type: Date, required: true },
 
-  //For now, chose to express these as strings. Will probably be replaced with
+  //For now, chose to express these as a list of strings. Will probably be replaced with
   //program subdocs in the future once they have been defined
-  prog1: { type: String, required: true },
-  prog2: { type: String, default: "" },
+  prog1: { type: [String], required: true },
+  prog2: { type: [String], default: "" },
 
   //Will contain list of all dietary restrictions
   dietary: { type: [String] },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.0.5",
+        "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-slot": "^1.0.2",
         "@testing-library/jest-dom": "^6.1.5",
@@ -1986,6 +1988,126 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz",
+      "integrity": "sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz",
+      "integrity": "sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz",
+      "integrity": "sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.4.tgz",
+      "integrity": "sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.4.tgz",
+      "integrity": "sha512-m8z/6Fyal4L9Bnlxde5g2Mfa1Z7dasMQyhEhskDATpqr+Y0mjOBZcXQ7G5U+vgL22cI4T7MfvgtrM2jdopqWaw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz",
+      "integrity": "sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz",
+      "integrity": "sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz",
+      "integrity": "sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "license": "MIT",
@@ -2075,6 +2197,34 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.0.5.tgz",
+      "integrity": "sha512-OrVIOcZL0tl6xibeuGt5/+UxoT2N27KCFOPjFyfXMnchxSHZ/OW7cCX2nGlIYJrbHK/fczPcFzAwvNBB6XBNMA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
@@ -2128,6 +2278,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+      "integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,8 @@
     "prepare": "cd .. && husky install .husky"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.0.5",
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-slot": "^1.0.2",
     "@testing-library/jest-dom": "^6.1.5",
@@ -29,9 +31,9 @@
     "react": "^18",
     "react-day-picker": "^8.10.0",
     "react-dom": "^18",
-    "tailwindcss": "^3.4.1",
     "react-hook-form": "^7.49.3",
     "tailwind-merge": "^2.2.0",
+    "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "ts-jest": "^29.1.1"
   },
@@ -49,9 +51,9 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "husky": "^8.0.3",
-    "prettier-plugin-tailwindcss": "^0.5.11",
     "postcss": "^8.4.33",
     "prettier": "^3.1.1",
+    "prettier-plugin-tailwindcss": "^0.5.11",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.1.1",
     "typescript": "^5"

--- a/frontend/src/components/Checkbox.tsx
+++ b/frontend/src/components/Checkbox.tsx
@@ -1,39 +1,71 @@
 "use client";
-import { FieldValues, UseFormRegister } from "react-hook-form";
+import { UseFormRegister } from "react-hook-form";
 
 import { cn } from "../lib/utils";
 
 import OtherCheckbox from "./OtherCheckbox";
+import { FormData } from "./StudentForm/types";
 
 type CheckboxProps = {
   options: string[];
   className?: string;
-  name: string;
-  register: UseFormRegister<FieldValues>;
+  name: keyof FormData;
+  defaultValue?: string[];
+  defaultOtherValue?: string;
+  register: UseFormRegister<FormData>;
 };
 
-export function Checkbox({ options, className, name, register }: CheckboxProps) {
+export function Checkbox({
+  options,
+  className,
+  name,
+  register,
+  defaultValue,
+  defaultOtherValue,
+}: CheckboxProps) {
   return (
-    <div className={cn("sm:min-w-2/5 min-w-4/5 grid gap-x-5 gap-y-3 sm:grid-cols-2", className)}>
+    <div className={cn("sm:min-w-2/5 min-w-4/5 grid gap-x-5 gap-y-5 sm:grid-cols-3", className)}>
       {options.map((item, index) => {
         return item === "Other" ? (
-          <OtherCheckbox register={register} key={item + index} />
+          <OtherCheckbox
+            register={register}
+            key={item + index}
+            defaultOtherValue={defaultOtherValue}
+          />
         ) : (
-          <div className="flex content-center justify-between " key={item + index}>
+          <div className="flex content-center items-center justify-between" key={item + index}>
             <label
               className="justify-left grid flex-1 select-none content-center py-[15px] hover:cursor-pointer"
               htmlFor={item + index}
             >
               {item}
             </label>
-            <input
-              {...register(name)}
-              id={item + index}
-              className="h-[40px] w-[40px] appearance-none  self-center rounded-[10px] bg-[#D9D9D9] checked:bg-pia_dark_green hover:cursor-pointer"
-              type="checkbox"
-              name={name}
-              value={item}
-            />
+            <div className="relative flex ">
+              <input
+                {...register(name)}
+                id={item + index}
+                className="peer h-[40px] w-[40px]  appearance-none rounded-[5px] bg-[#D9D9D9] transition-colors hover:cursor-pointer hover:bg-[#00686766] focus-visible:bg-[#00686766]"
+                type="checkbox"
+                name={name}
+                value={item}
+                defaultChecked={defaultValue?.includes(item.toLowerCase())}
+              />
+              <svg
+                className="pointer-events-none absolute inset-0 hidden h-[40px] w-[40px] peer-checked:block peer-checked:bg-white"
+                width="40"
+                height="40"
+                viewBox="0 0 40 40"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M4.44444 0C3.2657 0 2.13524 0.468252 1.30175 1.30175C0.468252 2.13524 0 3.2657 0 4.44444V35.5556C0 36.7343 0.468252 37.8648 1.30175 38.6983C2.13524 39.5317 3.2657 40 4.44444 40H35.5556C36.7343 40 37.8648 39.5317 38.6983 38.6983C39.5317 37.8648 40 36.7343 40 35.5556V4.44444C40 3.2657 39.5317 2.13524 38.6983 1.30175C37.8648 0.468252 36.7343 0 35.5556 0H4.44444ZM31 15.1022C31.417 14.6855 31.6514 14.1203 31.6516 13.5308C31.6518 12.9413 31.4178 12.3759 31.0011 11.9589C30.5844 11.5419 30.0192 11.3075 29.4297 11.3073C28.8402 11.3071 28.2748 11.5411 27.8578 11.9578L16.8578 22.9578L12.1444 18.2444C11.9381 18.038 11.6932 17.8742 11.4235 17.7624C11.1539 17.6506 10.8649 17.593 10.573 17.5929C9.98352 17.5927 9.41809 17.8267 9.00111 18.2433C8.58413 18.66 8.34976 19.2253 8.34955 19.8148C8.34934 20.4043 8.58332 20.9697 9 21.3867L15.1289 27.5156C15.3559 27.7427 15.6254 27.9228 15.9221 28.0457C16.2187 28.1687 16.5367 28.2319 16.8578 28.2319C17.1789 28.2319 17.4968 28.1687 17.7935 28.0457C18.0901 27.9228 18.3597 27.7427 18.5867 27.5156L31 15.1022Z"
+                  fill="#006867"
+                />
+              </svg>
+            </div>
           </div>
         );
       })}

--- a/frontend/src/components/OtherCheckbox.tsx
+++ b/frontend/src/components/OtherCheckbox.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FieldValues, UseFormRegister } from "react-hook-form";
 
 import { Textfield } from "./Textfield";
@@ -9,6 +9,22 @@ type OtherCheckboxProps = {
 
 export default function OtherCheckbox({ register }: OtherCheckboxProps) {
   const [checked, setChecked] = useState(false);
+
+  //Revert other checkbox when clicked outside
+  useEffect(() => {
+    if (checked) {
+      const otherInput = document.getElementById("OtherType Here...") as HTMLInputElement;
+      const handleOutsideClick = (e: MouseEvent) => {
+        if (!otherInput?.contains(e.target as Node) && otherInput?.value === "") {
+          setChecked(false);
+          document.removeEventListener("click", handleOutsideClick);
+        }
+      };
+      setTimeout(() => {
+        document.addEventListener("click", handleOutsideClick);
+      }, 0);
+    }
+  }, [checked]);
 
   return checked ? (
     <Textfield

--- a/frontend/src/components/OtherCheckbox.tsx
+++ b/frontend/src/components/OtherCheckbox.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useState } from "react";
-import { FieldValues, UseFormRegister } from "react-hook-form";
+import { UseFormRegister } from "react-hook-form";
 
+import { FormData } from "./StudentForm/types";
 import { Textfield } from "./Textfield";
 
 type OtherCheckboxProps = {
-  register: UseFormRegister<FieldValues>;
+  register: UseFormRegister<FormData>;
+  defaultOtherValue?: string;
 };
 
-export default function OtherCheckbox({ register }: OtherCheckboxProps) {
-  const [checked, setChecked] = useState(false);
+export default function OtherCheckbox({ register, defaultOtherValue = "" }: OtherCheckboxProps) {
+  const [checked, setChecked] = useState(defaultOtherValue !== "");
 
   //Revert other checkbox when clicked outside
   useEffect(() => {
@@ -33,6 +35,7 @@ export default function OtherCheckbox({ register }: OtherCheckboxProps) {
       name="other"
       label="Other"
       placeholder="Type Here..."
+      defaultValue={defaultOtherValue}
     />
   ) : (
     <div className="flex content-center justify-between ">

--- a/frontend/src/components/StudentForm/ContactInfo.tsx
+++ b/frontend/src/components/StudentForm/ContactInfo.tsx
@@ -1,0 +1,116 @@
+import { UseFormRegister } from "react-hook-form";
+
+import { cn } from "../../lib/utils";
+import { Textfield } from "../Textfield";
+
+import { FormData, StudentFormData } from "./types";
+
+type ContactRole = "student" | "emergency" | "serviceCoordinator";
+
+type PersonalInfoField = "firstName" | "lastName" | "email" | "phoneNumber";
+
+type ContactInfoProps = {
+  register: UseFormRegister<FormData>;
+  classname?: string;
+  type: "add" | "edit";
+  data: StudentFormData | null;
+};
+
+type FieldProps = {
+  name: string;
+  label: string;
+  placeholder: string;
+  type?: string;
+  defaultValue?: string;
+};
+
+type FinalFieldProps = {
+  name: keyof FormData;
+  label: string;
+  placeholder: string;
+  type?: string;
+  defaultValue?: string;
+};
+
+type DefaultFields = Record<PersonalInfoField, FieldProps>;
+
+type ContactInfo = Record<ContactRole, DefaultFields>;
+
+export default function ContactInfo({ register, type, data, classname }: ContactInfoProps) {
+  const defaultFields: DefaultFields = {
+    firstName: {
+      name: "name",
+      label: "First",
+      placeholder: "John",
+    },
+    lastName: {
+      name: "last",
+      label: "Last",
+      placeholder: "Smith",
+    },
+    email: {
+      name: "email",
+      label: "Email",
+      placeholder: "johnsmith@gmail.com",
+    },
+    phoneNumber: {
+      name: "phone",
+      label: "Phone #",
+      placeholder: "000-000-0000",
+      type: "tel",
+    },
+  };
+
+  const toTitleCase = (word: string) => {
+    return word
+      .split("_")
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase())
+      .join(" ");
+  };
+
+  const contactInfo: ContactInfo = {
+    //Deep copy
+    student: structuredClone(defaultFields),
+    emergency: structuredClone(defaultFields),
+    serviceCoordinator: structuredClone(defaultFields),
+  };
+
+  //Rename fields to be unique
+  Object.entries(contactInfo).forEach(([contactType, fieldList]) => {
+    Object.entries(fieldList).forEach(([_fieldType, fieldProps]) => {
+      fieldProps.name = `${contactType}_${fieldProps.name}`;
+    });
+  });
+
+  if (type === "edit" && data) {
+    //Set default input values from passed in student data
+    Object.entries(contactInfo).forEach(([contactType, fieldList]) => {
+      Object.entries(fieldList).forEach(([fieldType, fieldProps]) => {
+        fieldProps.defaultValue = data[contactType as ContactRole][fieldType as PersonalInfoField];
+      });
+    });
+  }
+
+  return (
+    <div className={cn("grid w-full grid-rows-3 gap-5", classname)}>
+      {Object.entries(contactInfo).map(([contactType, fieldList]) => {
+        return (
+          <div className="" key={contactType}>
+            <h3 className="mb-5">{toTitleCase(contactType)}</h3>
+            <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-4">
+              {Object.entries(fieldList).map(([_fieldType, fieldProps]) => {
+                return (
+                  <Textfield
+                    key={fieldProps.name}
+                    register={register}
+                    {...(fieldProps as FinalFieldProps)}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/StudentForm/StudentBackground.tsx
+++ b/frontend/src/components/StudentForm/StudentBackground.tsx
@@ -1,0 +1,70 @@
+import { UseFormRegister, UseFormSetValue } from "react-hook-form";
+
+import { cn } from "../../lib/utils";
+import { Checkbox } from "../Checkbox";
+import { Textfield } from "../Textfield";
+
+import { FormData, StudentFormData } from "./types";
+
+type StudentBackgroundProps = {
+  register: UseFormRegister<FormData>;
+  classname?: string;
+  setCalendarValue: UseFormSetValue<FormData>;
+  data: StudentFormData | null;
+};
+
+const dietaryList = ["Nuts", "Eggs", "Seafood", "Pollen", "Dairy", "Other"];
+
+export default function StudentBackground({
+  data,
+  register,
+  classname,
+  setCalendarValue,
+}: StudentBackgroundProps) {
+  return (
+    <div className="grid w-full gap-5 lg:grid-cols-2">
+      <div className={cn("grid flex-1 gap-x-3 gap-y-5 md:grid-cols-2", classname)}>
+        <div>
+          <h3 className="block">Address</h3>
+          <Textfield
+            register={register}
+            name="address"
+            placeholder="123 Maple St"
+            defaultValue={data?.location}
+          />
+        </div>
+        <div>
+          <h3>Birthdate</h3>
+          <Textfield
+            register={register}
+            name="birthdate"
+            placeholder="00/00/0000"
+            calendar={true}
+            setCalendarValue={setCalendarValue}
+            defaultValue={data?.birthday}
+          />
+        </div>
+        <div>
+          <h3>Mediciation</h3>
+          <Textfield
+            register={register}
+            name="medication"
+            placeholder="Specify"
+            defaultValue={data?.medication}
+          />
+        </div>
+      </div>
+      <div className="flex-1">
+        <h3>Dietary Restrictions</h3>
+        <Checkbox
+          register={register}
+          name="dietary"
+          options={dietaryList}
+          defaultValue={data?.dietary.map((item) => item.toLowerCase())}
+          defaultOtherValue={data?.otherString}
+          className="sm:grid-cols-2 min-[1150px]:grid-cols-3"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StudentForm/StudentInfo.tsx
+++ b/frontend/src/components/StudentForm/StudentInfo.tsx
@@ -1,0 +1,73 @@
+import { UseFormRegister, UseFormSetValue } from "react-hook-form";
+
+import { cn } from "../../lib/utils";
+import { Checkbox } from "../Checkbox";
+import { Textfield } from "../Textfield";
+
+import { FormData, StudentFormData } from "./types";
+
+type StudentInfoProps = {
+  register: UseFormRegister<FormData>;
+  classname?: string;
+  setCalendarValue: UseFormSetValue<FormData>;
+  data: StudentFormData | null;
+};
+
+const regularPrograms = ["Intro", "ENTR"];
+const varyingPrograms = ["TDS", "SDP"];
+
+export default function StudentInfo({
+  register,
+  classname,
+  setCalendarValue,
+  data,
+}: StudentInfoProps) {
+  return (
+    <div className="grid w-full gap-5 lg:grid-cols-2">
+      <div className={cn("grid flex-1 gap-x-3 gap-y-5 md:grid-cols-2", classname)}>
+        <div>
+          <h3>Intake date</h3>
+          <Textfield
+            register={register}
+            name="intake_date"
+            placeholder="00/00/0000"
+            calendar={true}
+            setCalendarValue={setCalendarValue}
+            defaultValue={data?.intakeDate}
+          />
+        </div>
+        <div>
+          <h3>Tour date</h3>
+          <Textfield
+            register={register}
+            name="tour_date"
+            placeholder="00/00/0000"
+            calendar={true}
+            setCalendarValue={setCalendarValue}
+            defaultValue={data?.tourDate}
+          />
+        </div>
+      </div>
+      <div className="grid gap-y-5">
+        <div>
+          <h3>Regular Programs</h3>
+          <Checkbox
+            register={register}
+            name="regular_programs"
+            options={regularPrograms}
+            defaultValue={data?.prog1}
+          />
+        </div>
+        <div>
+          <h3>Varying Programs</h3>
+          <Checkbox
+            register={register}
+            name="regular_programs"
+            options={varyingPrograms}
+            defaultValue={data?.prog2}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StudentForm/types.ts
+++ b/frontend/src/components/StudentForm/types.ts
@@ -1,0 +1,44 @@
+export type Contact = {
+  lastName: string;
+  firstName: string;
+  email: string;
+  phoneNumber: string;
+};
+
+export type StudentFormData = {
+  student: Contact;
+  emergency: Contact;
+  serviceCoordinator: Contact;
+  location: string;
+  medication: string;
+  birthday: string;
+  intakeDate: string;
+  tourDate: string;
+  prog1: string[];
+  prog2: string[];
+  dietary: string[];
+  otherString: string;
+};
+
+export type FormData = {
+  student_name: string;
+  student_last: string;
+  student_email: string;
+  student_phone: string;
+  emergency_name: string;
+  emergency_last: string;
+  emergency_email: string;
+  emergency_phone: string;
+  serviceCoordinator_name: string;
+  serviceCoordinator_last: string;
+  serviceCoordinator_email: string;
+  serviceCoordinator_phone: string;
+  address: string;
+  birthdate: string;
+  medication: string;
+  dietary: string[];
+  other: string;
+  intake_date: string;
+  tour_date: string;
+  regular_programs: string[];
+};

--- a/frontend/src/components/StudentFormButton.tsx
+++ b/frontend/src/components/StudentFormButton.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
+
+import { cn } from "../lib/utils";
+
+import { Button } from "./Button";
+import ContactInfo from "./StudentForm/ContactInfo";
+import StudentBackground from "./StudentForm/StudentBackground";
+import StudentInfo from "./StudentForm/StudentInfo";
+import { FormData, StudentFormData } from "./StudentForm/types";
+import { Dialog, DialogClose, DialogContent, DialogTrigger } from "./ui/dialog";
+
+type BaseProps = {
+  classname?: string;
+};
+
+type EditProps = BaseProps & {
+  type: "edit";
+  data: StudentFormData | null;
+};
+
+type AddProps = BaseProps & {
+  type: "add";
+  data?: StudentFormData | null;
+};
+
+type StudentFormProps = EditProps | AddProps;
+
+export default function StudentFormButton({
+  type = "edit",
+  data = null,
+  classname,
+}: StudentFormProps) {
+  const { register, setValue: setCalendarValue, handleSubmit } = useForm<FormData>();
+
+  const onSubmit: SubmitHandler<FormData> = (formData: FormData) => {
+    const transformedData: StudentFormData = {
+      student: {
+        firstName: formData.student_name,
+        lastName: formData.student_last,
+        email: formData.student_email,
+        phoneNumber: formData.student_phone,
+      },
+      emergency: {
+        firstName: formData.emergency_name,
+        lastName: formData.emergency_last,
+        email: formData.emergency_email,
+        phoneNumber: formData.emergency_phone,
+      },
+      serviceCoordinator: {
+        firstName: formData.serviceCoordinator_name,
+        lastName: formData.serviceCoordinator_last,
+        email: formData.serviceCoordinator_email,
+        phoneNumber: formData.serviceCoordinator_phone,
+      },
+      location: formData.address,
+      medication: formData.medication,
+      birthday: formData.birthdate,
+      intakeDate: formData.intake_date,
+      tourDate: formData.tour_date,
+      prog1: formData.regular_programs,
+      prog2: formData.regular_programs,
+      dietary: formData.dietary,
+      otherString: formData.other,
+    };
+
+    console.log(`${type} student data:`, transformedData);
+  };
+
+  const [openForm, setOpenForm] = useState(false);
+
+  return (
+    <>
+      <Dialog open={openForm} onOpenChange={setOpenForm}>
+        <DialogTrigger asChild>
+          <Button
+            label={type === "add" ? "Add Student" : "View Profile"}
+            onClick={() => {
+              setOpenForm(true);
+            }}
+          />
+        </DialogTrigger>
+        <DialogContent className="max-h-[95%] max-w-[98%] rounded-[13px] sm:max-w-[80%]">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className={cn(
+              "flex flex-col justify-between gap-5 rounded-md bg-white px-[calc(3vw+2px)] py-10 sm:p-10",
+              classname,
+            )}
+          >
+            <fieldset>
+              <legend className="mb-5 w-full text-left font-bold">Contact Information</legend>
+              <ContactInfo register={register} data={data ?? null} type={type} />
+            </fieldset>
+            <fieldset>
+              <legend className="mb-5 w-full text-left font-bold">Student Background</legend>
+              <StudentBackground
+                register={register}
+                data={data ?? null}
+                setCalendarValue={setCalendarValue}
+              />
+            </fieldset>
+            <fieldset>
+              <legend className="mb-5 w-full text-left font-bold">Student Information</legend>
+              <StudentInfo
+                register={register}
+                data={data ?? null}
+                setCalendarValue={setCalendarValue}
+              />
+            </fieldset>
+            <div className="ml-auto mt-5 flex gap-5">
+              {/* Modal Confirmation Dialog */}
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button label="Cancel" kind="secondary" />
+                </DialogTrigger>
+                <DialogContent className="max-h-[30%] max-w-[80%] rounded-[8px] md:max-w-[50%]  lg:max-w-[30%]">
+                  <div className="p-3 min-[450px]:p-10">
+                    <p className="my-10 text-center">Leave without saving changes?</p>
+                    <div className="grid justify-center gap-5 min-[450px]:flex min-[450px]:justify-between">
+                      <DialogClose asChild>
+                        <Button label="Back" kind="secondary" />
+                      </DialogClose>
+                      <DialogClose asChild>
+                        <Button
+                          label="Continue"
+                          onClick={() => {
+                            setOpenForm(false);
+                          }}
+                        />
+                      </DialogClose>
+                    </div>
+                  </div>
+                </DialogContent>
+              </Dialog>
+              <DialogClose asChild>
+                <Button label="Save Changes" type="submit" />
+              </DialogClose>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/components/StudentFormButton.tsx
+++ b/frontend/src/components/StudentFormButton.tsx
@@ -31,7 +31,7 @@ export default function StudentFormButton({
   data = null,
   classname,
 }: StudentFormProps) {
-  const { register, setValue: setCalendarValue, handleSubmit } = useForm<FormData>();
+  const { register, setValue: setCalendarValue, reset, handleSubmit } = useForm<FormData>();
 
   const onSubmit: SubmitHandler<FormData> = (formData: FormData) => {
     const transformedData: StudentFormData = {
@@ -63,7 +63,7 @@ export default function StudentFormButton({
       dietary: formData.dietary,
       otherString: formData.other,
     };
-
+    reset(); //Clear form
     console.log(`${type} student data:`, transformedData);
   };
 

--- a/frontend/src/components/Textfield.tsx
+++ b/frontend/src/components/Textfield.tsx
@@ -1,53 +1,57 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { FieldValues, UseFormRegister, UseFormSetValue } from "react-hook-form";
+import { UseFormRegister, UseFormSetValue } from "react-hook-form";
 
 import { Calendar } from "../components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popover";
 import { cn } from "../lib/utils";
 
+import { FormData } from "./StudentForm/types";
+
 type BaseProps = {
-  register: UseFormRegister<FieldValues>;
-  name: string;
+  register: UseFormRegister<FormData>;
+  name: keyof FormData;
   label?: string;
   type?: string;
   placeholder: string;
+  defaultValue?: string;
   className?: string;
 };
 
 type WithCalendarProps = BaseProps & {
-  calendar: true; // When calendar is true, setValue is required
-  setValue: UseFormSetValue<FieldValues>;
+  calendar: true; // When calendar is true, setCalendarValue is required
+  setCalendarValue: UseFormSetValue<FormData>;
 };
 
 type WithoutCalendarProps = BaseProps & {
-  calendar?: false; // When calendar is false or not provided, setValue is optional
-  setValue?: UseFormSetValue<FieldValues>;
+  calendar?: false; // When calendar is false or not provided, setCalendarValue is optional
+  setCalendarValue?: UseFormSetValue<FormData>;
 };
 
 type TextFieldProps = WithCalendarProps | WithoutCalendarProps;
 
 export function Textfield({
   register,
-  setValue,
+  setCalendarValue,
   label,
   name,
   placeholder,
   calendar = false,
   className,
   type = "text",
+  defaultValue = "",
 }: TextFieldProps) {
   const [date, setDate] = useState<Date>();
 
   useEffect(() => {
-    if (date && setValue) {
+    if (date && setCalendarValue) {
       const parsedDate = date.toLocaleDateString(undefined, {
         year: "numeric",
         month: "2-digit",
         day: "2-digit",
       });
-      setValue(name, parsedDate);
+      setCalendarValue(name, parsedDate);
     }
   }, [date]);
 
@@ -55,7 +59,7 @@ export function Textfield({
     <Popover>
       <div
         className={cn(
-          "relative flex rounded-md border-[1px] border-pia_border px-2 py-3 focus-within:border-pia_dark_green ",
+          "relative flex flex-grow rounded-md border-[1px] border-pia_border px-2 py-3 focus-within:border-pia_dark_green ",
           className,
         )}
       >
@@ -65,6 +69,15 @@ export function Textfield({
           id={label + placeholder}
           type={type}
           placeholder={placeholder}
+          defaultValue={
+            calendar && defaultValue
+              ? new Date(defaultValue).toLocaleDateString(undefined, {
+                  year: "numeric",
+                  month: "2-digit",
+                  day: "2-digit",
+                })
+              : defaultValue
+          }
         />
 
         {label ? (

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import { Poppins } from "next/font/google";
 import * as React from "react";
 import { DayPicker } from "react-day-picker";
 
@@ -8,11 +9,13 @@ import { buttonVariants } from "./button";
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 
+const poppins = Poppins({ subsets: ["latin"], weight: "400" });
+
 function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
+      className={cn("font-poppins p-3", className, poppins.className)}
       classNames={{
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
         month: "space-y-4",

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -39,7 +39,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         ),
         day_range_end: "day-range-end",
         day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+          "bg-pia_dark_green text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-pia_dark_green focus:text-primary-foreground",
         day_today: "bg-accent text-accent-foreground",
         day_outside:
           "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,101 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Poppins } from "next/font/google";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const poppins = Poppins({ subsets: ["latin"], weight: "400" });
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "font fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "scrollbar fixed left-[50%] top-[50%] z-50 grid max-h-[100%] w-full max-w-[100%]  translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+        poppins.className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/frontend/src/constants/navigation.tsx
+++ b/frontend/src/constants/navigation.tsx
@@ -77,8 +77,8 @@ export const navigation: NavigationEntry[] = [
         fill="inherit"
       >
         <path
-          fill-rule="evenodd"
-          clip-rule="evenodd"
+          fillRule="evenodd"
+          clipRule="evenodd"
           d="M13 3C13 2.44772 12.5523 2 12 2C11.4477 2 11 2.44772 11 3V4.08296C8.16229 4.55904 6 7.027 6 10V14.6972L4.16795 17.4453C3.96338 17.7522 3.94431 18.1467 4.11833 18.4719C4.29235 18.797 4.63121 19 5 19H19C19.3688 19 19.7077 18.797 19.8817 18.4719C20.0557 18.1467 20.0366 17.7522 19.8321 17.4453L18 14.6972V10C18 7.027 15.8377 4.55904 13 4.08296V3ZM12 6C9.79086 6 8 7.79086 8 10V15C8 15.1974 7.94156 15.3904 7.83205 15.5547L6.86852 17H17.1315L16.168 15.5547C16.0584 15.3904 16 15.1974 16 15V10C16 7.79086 14.2091 6 12 6Z"
           fill="inherit"
         />
@@ -87,20 +87,20 @@ export const navigation: NavigationEntry[] = [
           fill="inherit"
         />
         <path
-          fill-rule="evenodd"
-          clip-rule="evenodd"
+          fillRule="evenodd"
+          clipRule="evenodd"
           d="M13 3C13 2.44772 12.5523 2 12 2C11.4477 2 11 2.44772 11 3V4.08296C8.16229 4.55904 6 7.027 6 10V14.6972L4.16795 17.4453C3.96338 17.7522 3.94431 18.1467 4.11833 18.4719C4.29235 18.797 4.63121 19 5 19H19C19.3688 19 19.7077 18.797 19.8817 18.4719C20.0557 18.1467 20.0366 17.7522 19.8321 17.4453L18 14.6972V10C18 7.027 15.8377 4.55904 13 4.08296V3ZM12 6C9.79086 6 8 7.79086 8 10V15C8 15.1974 7.94156 15.3904 7.83205 15.5547L6.86852 17H17.1315L16.168 15.5547C16.0584 15.3904 16 15.1974 16 15V10C16 7.79086 14.2091 6 12 6Z"
           stroke="inherit"
-          stroke-width="0.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
         <path
           d="M12 22C13.1046 22 14 21.1046 14 20H10C10 21.1046 10.8954 22 12 22Z"
           stroke="inherit"
-          stroke-width="0.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     ),

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,55 +1,11 @@
-import { FieldValues, SubmitHandler, useForm } from "react-hook-form";
-
-import { Checkbox } from "../components/Checkbox";
-import Radio from "../components/Radio";
-import { Textfield } from "../components/Textfield";
+import StudentFormButton from "../components/StudentFormButton";
+import sampleStudentData from "../sampleStudentData.json";
 
 export default function Home() {
-  const dietaryList = ["Nuts", "Eggs", "Seafood", "Pollen", "Dairy", "Other"];
-
-  const { register, setValue, handleSubmit } = useForm();
-
-  const onSubmit: SubmitHandler<FieldValues> = (data) => {
-    console.log(data);
-  };
-
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="flex flex-col items-center justify-between gap-10 p-12"
-    >
-      <div className="grid gap-5">
-        <Textfield register={register} name={"firstname"} label="First" placeholder="John" />
-        <Textfield
-          register={register}
-          name={"email"}
-          label={"Email"}
-          type="email"
-          placeholder="johnsmith@gmail.com"
-        />
-        <Textfield
-          register={register}
-          setValue={setValue}
-          name={"date"}
-          label="Date"
-          placeholder="00/00/0000"
-          calendar={true}
-        />
-      </div>
-
-      <div className="grid w-full sm:w-1/2 ">
-        <h2 className="mb-2 text-pia_accent">Dietary Restrictions</h2>
-        <Checkbox register={register} name="dietary" options={dietaryList} />
-      </div>
-
-      <div className="">
-        <h2 className="mb-5 text-2xl font-bold">Gender</h2>
-        <Radio register={register} name="gender" options={["Male", "Female", "Rather not say"]} />
-      </div>
-
-      <button type="submit" className="rounded-md bg-pia_dark_green px-5 py-3 text-white">
-        Submit
-      </button>
-    </form>
+    <div className="grid w-40 gap-5">
+      <StudentFormButton type="edit" data={sampleStudentData} />
+      <StudentFormButton type="add" />
+    </div>
   );
 }

--- a/frontend/src/sampleStudentData.json
+++ b/frontend/src/sampleStudentData.json
@@ -1,0 +1,29 @@
+{
+  "student": {
+    "firstName": "John",
+    "lastName": "Doe",
+    "email": "John@aol.com",
+    "phoneNumber": "1005882300"
+  },
+  "emergency": {
+    "firstName": "Bob",
+    "lastName": "James",
+    "email": "bob@aol.com",
+    "phoneNumber": "2005882300"
+  },
+  "serviceCoordinator": {
+    "firstName": "William",
+    "lastName": "John",
+    "email": "William@aol.com",
+    "phoneNumber": "3005882300"
+  },
+  "location": "HERE",
+  "medication": "ADVIL",
+  "birthday": "2023-10-01T00:00Z",
+  "intakeDate": "2023-10-03T00:00Z",
+  "tourDate": "2023-10-05T00:00Z",
+  "prog1": ["intro"],
+  "prog2": ["tds", "sdp"],
+  "dietary": ["seafood", "dairy"],
+  "otherString": "peanuts"
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -82,3 +82,24 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .scrollbar::-webkit-scrollbar {
+    width: 12px;
+  }
+
+  .scrollbar::-webkit-scrollbar-track {
+    border-radius: 100vh;
+    background: #f7f4ed;
+  }
+
+  .scrollbar::-webkit-scrollbar-thumb {
+    background: #006867;
+    border-radius: 100vh;
+    border: 3px solid #f6f7ed;
+  }
+
+  .scrollbar::-webkit-scrollbar-thumb:hover {
+    background: #59807f;
+  }
+}


### PR DESCRIPTION
## Tracking Info

Resolves #28

## Changes

<!-- What changes did you make? -->

- Added responsive student form button component with modal (dialog) support with `shadcn`
- Updated 'Other' checkbox to revert to checkbox when empty and clicked outside of input area
- Updated student form design to be same as V2 design
- Matched student schema defined in `/backend/src/models/student.s` with form data structure
- Updated backend schema so that program1 and program2 are defined to be a list of strings as they can be checked
- `StudentFormButton` currently takes in the student data as a prop when editing an existing student. We may want to consider only fetching the data when the 'View Profile' button is clicked rather than fetching all the data at once and populating all the buttons on page load.

## Testing

- I created a `sampleStudentData.json` file in `frontend/src` (**DO NOT INCLUDE IN MERGE**) to test for editing a student form so that it has populated data. This data is based on Michael's sample request body structure in #32
- To test for editing and adding a student, I checked the console to see if the logged data matches the inputted data

## Confirmation of Change

<img width="156" alt="image" src="https://github.com/TritonSE/PIA-Program-Manager/assets/42254254/e5bc2bc8-e39b-42b4-bb44-0c0b651a43b2">
<img width="1274" alt="image" src="https://github.com/TritonSE/PIA-Program-Manager/assets/42254254/00b91f49-6596-4d42-afd6-ecfe7e42c737">
<img width="1271" alt="image" src="https://github.com/TritonSE/PIA-Program-Manager/assets/42254254/8200f1a2-2b02-4d3d-b965-3a15223bd2e1">

